### PR TITLE
DO NOT MERGE - Updates to pg-audit_log for Rails 6 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+# IDEs
+.idea/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ rvm:
 
 env:
   - RAILS_VERSION="~> 4.2.0"
-  - RAILS_VERSION="~> 5.0.0"
+  - RAILS_VERSION="~> 6.0.0"
   - RAILS_BRANCH="master"
 
 matrix:
@@ -23,6 +23,6 @@ matrix:
     - env: RAILS_BRANCH="master"
   exclude:
     - rvm: "2.1.10"
-      env: RAILS_VERSION="~> 5.0.0"
+      env: RAILS_VERSION="~> 6.0.0"
     - rvm: "2.1.10"
       env: RAILS_BRANCH="master"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,21 @@ before_script:
   - psql -c 'CREATE DATABASE pg_audit_log_test;' -U postgres
 
 rvm:
-  - "1.9"
-  - "2.0"
-  - "2.1"
-  - "2.2"
-  #- jruby-19mode
-  - rbx-2.2
+  - "2.1.10"
+  - "2.2.6"
+  - "2.3.3"
+  - "2.4.1"
 
 env:
   - RAILS_VERSION="~> 4.2.0"
-  - RAILS_VERSION="~> 4.1.0"
-  - RAILS_VERSION="~> 4.0.0"
-  - RAILS_VERSION="~> 3.2.0"
+  - RAILS_VERSION="~> 5.0.0"
+  - RAILS_BRANCH="master"
 
 matrix:
   allow_failures:
     - env: RAILS_BRANCH="master"
+  exclude:
+    - rvm: "2.1.10"
+      env: RAILS_VERSION="~> 5.0.0"
+    - rvm: "2.1.10"
+      env: RAILS_BRANCH="master"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,8 @@
 - Introduce changelog.
 - Support Rails 4.2 (no code change, dependency requirement bump only).
 - Update Rails generator for Rails 4.x (Daniel Grippi).
+
+
+### 0.7.0
+
+- Support Rails 5.2 (no code change, dependency requirement bump only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.7.0
+
+- Support Rails 5.2 (no code change, dependency requirement bump only).
+
+
 ### 0.6.7
 - Fix nested calls to 'without_triggers'.
 
@@ -12,8 +17,3 @@
 - Introduce changelog.
 - Support Rails 4.2 (no code change, dependency requirement bump only).
 - Update Rails generator for Rails 4.x (Daniel Grippi).
-
-
-### 0.7.0
-
-- Support Rails 5.2 (no code change, dependency requirement bump only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.6.7
+- Fix nested calls to 'without_triggers'.
+
+
 ### 0.6.6
 - Bump Rails dependency to include all 4.2.x (@MrJaba)
 - Fixed migration name to be .rb file (@MrJaba)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ On a 2.93GHz i7 with PostgreSQL 9.1 the audit log has an overhead of about 0.003
 
 - ActiveRecord
 - PostgreSQL
-- Rails 3.2, 4.x
+- Rails 3.2, 4.x, 5.x
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ On a 2.93GHz i7 with PostgreSQL 9.1 the audit log has an overhead of about 0.003
 
 - ActiveRecord
 - PostgreSQL
-- Rails 3.2, 4.x, 5.x
+- Rails 3.2, 4.x, 5.x, 6.x
 
 ## LICENSE
 

--- a/lib/pg_audit_log/entry.rb
+++ b/lib/pg_audit_log/entry.rb
@@ -67,7 +67,7 @@ class PgAuditLog::Entry < ActiveRecord::Base
         $$
         LANGUAGE plpgsql;
 
-        CREATE TRIGGER OR REPLACE insert_audit_log_trigger
+        CREATE OR REPLACE TRIGGER insert_audit_log_trigger
           BEFORE INSERT ON audit_log
           FOR EACH ROW EXECUTE PROCEDURE audit_log_insert_trigger();
       SQL

--- a/lib/pg_audit_log/entry.rb
+++ b/lib/pg_audit_log/entry.rb
@@ -19,11 +19,11 @@ class PgAuditLog::Entry < ActiveRecord::Base
 
     def install
       sql = <<-SQL
-        CREATE SEQUENCE #{self.table_name}_id_seq
+        CREATE SEQUENCE IF NOT EXISTS #{self.table_name}_id_seq
             START WITH 1
             INCREMENT BY 1;
 
-        CREATE TABLE #{self.table_name} (
+        CREATE TABLE IF NOT EXISTS #{self.table_name} (
             id bigint PRIMARY KEY DEFAULT nextval('#{self.table_name}_id_seq'),
             user_id integer,
             user_unique_name character varying(255),
@@ -67,7 +67,7 @@ class PgAuditLog::Entry < ActiveRecord::Base
         $$
         LANGUAGE plpgsql;
 
-        CREATE TRIGGER insert_audit_log_trigger
+        CREATE TRIGGER OR REPLACE insert_audit_log_trigger
           BEFORE INSERT ON audit_log
           FOR EACH ROW EXECUTE PROCEDURE audit_log_insert_trigger();
       SQL

--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -3,7 +3,7 @@ require 'active_record/connection_adapters/postgresql_adapter'
 # Did not want to reopen the class but sending an include seemingly is not working.
 class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   def create_table_with_auditing(table_name, options = {}, &block)
-    create_table_without_auditing(table_name, options, &block)
+    create_table_without_auditing(table_name, **options, &block)
     unless options[:temporary] ||
       PgAuditLog::IGNORED_TABLES.include?(table_name) ||
       PgAuditLog::IGNORED_TABLES.any? { |table| table =~ table_name if table.is_a? Regexp } ||

--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -65,8 +65,8 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   alias_method :exec_update_without_pg_audit_log, :exec_update
   alias_method :exec_update, :exec_update_with_pg_audit_log
 
-  def reconnect_with_pg_audit_log!
-    reconnect_without_pg_audit_log!
+  def reconnect_with_pg_audit_log!(*args, **opts)
+    reconnect_without_pg_audit_log!(*args, **opts)
     @last_user_id = @last_unique_name = nil
   end
 

--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -2,76 +2,90 @@ require 'active_record/connection_adapters/postgresql_adapter'
 
 # Did not want to reopen the class but sending an include seemingly is not working.
 class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-
-  module Auditing
-    def create_table(table_name, options = {}, &block)
-      super(table_name, options, &block)
-      unless options[:temporary] ||
-        PgAuditLog::IGNORED_TABLES.include?(table_name) ||
-        PgAuditLog::IGNORED_TABLES.any? { |table| table =~ table_name if table.is_a? Regexp } ||
-        PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
-        PgAuditLog::Triggers.create_for_table(table_name)
-      end
+  def create_table_with_auditing(table_name, options = {}, &block)
+    create_table_without_auditing(table_name, options, &block)
+    unless options[:temporary] ||
+      PgAuditLog::IGNORED_TABLES.include?(table_name) ||
+      PgAuditLog::IGNORED_TABLES.any? { |table| table =~ table_name if table.is_a? Regexp } ||
+      PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
+      PgAuditLog::Triggers.create_for_table(table_name)
     end
+  end
 
-    def drop_table(table_name)
-      if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
-        PgAuditLog::Triggers.drop_for_table(table_name)
-      end
-      super(table_name)
+  alias_method :create_table_without_auditing, :create_table
+  alias_method :create_table, :create_table_with_auditing
+
+  def drop_table_with_auditing(table_name)
+    if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
+      PgAuditLog::Triggers.drop_for_table(table_name)
     end
+    drop_table_without_auditing(table_name)
+  end
 
-    def rename_table(table_name, new_name)
-      if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
-        PgAuditLog::Triggers.drop_for_table(table_name)
-      end
-      super(table_name, new_name)
-      unless PgAuditLog::IGNORED_TABLES.include?(table_name) ||
-        PgAuditLog::IGNORED_TABLES.any? { |table| table =~ table_name if table.is_a? Regexp } ||
+  alias_method :drop_table_without_auditing, :drop_table
+  alias_method :drop_table, :drop_table_with_auditing
+
+  def rename_table_with_auditing(table_name, new_name)
+    if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
+      PgAuditLog::Triggers.drop_for_table(table_name)
+    end
+    rename_table_without_auditing(table_name, new_name)
+    unless PgAuditLog::IGNORED_TABLES.include?(table_name) ||
+      PgAuditLog::IGNORED_TABLES.any? { |table| table =~ table_name if table.is_a? Regexp } ||
+      PgAuditLog::Triggers.tables_with_triggers.include?(new_name)
+      PgAuditLog::IGNORED_TABLES.any? { |table| table =~ table_name if table.is_a? Regexp } ||
         PgAuditLog::Triggers.tables_with_triggers.include?(new_name)
-        PgAuditLog::Triggers.create_for_table(new_name)
-      end
-
+      PgAuditLog::Triggers.create_for_table(new_name)
     end
   end
+  alias_method :rename_table_without_auditing, :rename_table
+  alias_method :rename_table, :rename_table_with_auditing
 
-
-  module PgAuditLog
-    def reconnect!
-      super
-      @last_user_id = @last_unique_name = nil
-    end
-
-    def execute(sql, name = nil)
-      set_audit_user_id_and_name
-      super(sql, name)
-    end
-
-    def exec_query(*args, &block)
-      set_audit_user_id_and_name
-      super(*args, &block)
-    end
-
-    def exec_update(*args, &block)
-      set_audit_user_id_and_name
-      super(*args, &block)
-    end
-
-    def exec_delete(*args, &block)
-      set_audit_user_id_and_name
-      super(*args, &block)
-    end
+  def execute_with_pg_audit_log(sql, name = nil)
+    set_audit_user_id_and_name
+    execute_without_pg_audit_log(sql, name)
   end
 
-  prepend ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::Auditing
-  prepend ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::PgAuditLog
+  alias_method :execute_without_pg_audit_log, :execute
+  alias_method :execute, :execute_with_pg_audit_log
+
+  def exec_query_with_pg_audit_log(sql, name = 'SQL', binds = [], prepare = false)
+    set_audit_user_id_and_name
+    exec_query_without_pg_audit_log(sql, name, binds)
+  end
+
+  alias_method :exec_query_without_pg_audit_log, :exec_query
+  alias_method :exec_query, :exec_query_with_pg_audit_log
+
+  def exec_update_with_pg_audit_log(sql, name = 'SQL', binds = [])
+    set_audit_user_id_and_name
+    exec_update_without_pg_audit_log(sql, name, binds)
+  end
+
+  alias_method :exec_update_without_pg_audit_log, :exec_update
+  alias_method :exec_update, :exec_update_with_pg_audit_log
+
+  def reconnect_with_pg_audit_log!
+    reconnect_without_pg_audit_log!
+    @last_user_id = @last_unique_name = nil
+  end
+
+  alias_method :reconnect_without_pg_audit_log!, :reconnect!
+  alias_method :reconnect!, :reconnect_with_pg_audit_log!
+
+  def exec_delete_with_pg_audit_log(sql, name = 'SQL', binds = [])
+    set_audit_user_id_and_name
+    exec_delete_without_pg_audit_log(sql, name, binds)
+  end
+
+  alias_method :exec_delete_without_pg_audit_log, :exec_delete
+  alias_method :exec_delete, :exec_delete_with_pg_audit_log
 
   def set_audit_user_id_and_name
     user_id, unique_name = user_id_and_name
     return true if (@last_user_id && @last_user_id == user_id) && (@last_unique_name && @last_unique_name == unique_name)
-
-    PgAuditLog.execute PgAuditLog::Function::user_identifier_temporary_function(user_id)
-    PgAuditLog.execute PgAuditLog::Function::user_unique_name_temporary_function(unique_name)
+    execute_without_pg_audit_log PgAuditLog::Function::user_identifier_temporary_function(user_id)
+    execute_without_pg_audit_log PgAuditLog::Function::user_unique_name_temporary_function(unique_name)
     @last_user_id     = user_id
     @last_unique_name = unique_name
 
@@ -79,7 +93,7 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   end
 
   def set_user_id(user_id = nil)
-    PgAuditLog.execute PgAuditLog::Function::user_identifier_temporary_function(user_id || @last_user_id)
+    execute_without_pg_audit_log PgAuditLog::Function::user_identifier_temporary_function(user_id || @last_user_id)
   end
 
   def blank_audit_user_id_and_name

--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -25,11 +25,11 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   alias_method :drop_table_without_auditing, :drop_table
   alias_method :drop_table, :drop_table_with_auditing
 
-  def rename_table_with_auditing(table_name, new_name)
+  def rename_table_with_auditing(table_name, new_name, **options)
     if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
       PgAuditLog::Triggers.drop_for_table(table_name)
     end
-    rename_table_without_auditing(table_name, new_name)
+    rename_table_without_auditing(table_name, new_name, **options)
     unless PgAuditLog::IGNORED_TABLES.include?(table_name) ||
       PgAuditLog::IGNORED_TABLES.any? { |table| table =~ table_name if table.is_a? Regexp } ||
       PgAuditLog::Triggers.tables_with_triggers.include?(new_name)

--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -2,52 +2,84 @@ require 'active_record/connection_adapters/postgresql_adapter'
 
 # Did not want to reopen the class but sending an include seemingly is not working.
 class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-  def drop_table_with_auditing(table_name)
-    if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
-      PgAuditLog::Triggers.drop_for_table(table_name)
-    end
-    drop_table_without_auditing(table_name)
-  end
-  alias_method_chain :drop_table, :auditing
 
-  def create_table_with_auditing(table_name, options = {}, &block)
-    create_table_without_auditing(table_name, options, &block)
-    unless options[:temporary] ||
+  module Auditing
+    def create_table(table_name, options = {}, &block)
+      super(table_name, options, &block)
+      unless options[:temporary] ||
         PgAuditLog::IGNORED_TABLES.include?(table_name) ||
         PgAuditLog::IGNORED_TABLES.any? { |table| table =~ table_name if table.is_a? Regexp } ||
         PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
-      PgAuditLog::Triggers.create_for_table(table_name)
+        PgAuditLog::Triggers.create_for_table(table_name)
+      end
     end
-  end
-  alias_method_chain :create_table, :auditing
 
-  def rename_table_with_auditing(table_name, new_name)
-    if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
-      PgAuditLog::Triggers.drop_for_table(table_name)
+    def drop_table(table_name)
+      if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
+        PgAuditLog::Triggers.drop_for_table(table_name)
+      end
+      super(table_name)
     end
-    rename_table_without_auditing(table_name, new_name)
-    unless PgAuditLog::IGNORED_TABLES.include?(table_name) ||
+
+    def rename_table(table_name, new_name)
+      if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
+        PgAuditLog::Triggers.drop_for_table(table_name)
+      end
+      super(table_name, new_name)
+      unless PgAuditLog::IGNORED_TABLES.include?(table_name) ||
         PgAuditLog::IGNORED_TABLES.any? { |table| table =~ table_name if table.is_a? Regexp } ||
         PgAuditLog::Triggers.tables_with_triggers.include?(new_name)
-      PgAuditLog::Triggers.create_for_table(new_name)
+        PgAuditLog::Triggers.create_for_table(new_name)
+      end
+
     end
   end
-  alias_method_chain :rename_table, :auditing
+
+
+  module PgAuditLog
+    def reconnect!
+      super
+      @last_user_id = @last_unique_name = nil
+    end
+
+    def execute(sql, name = nil)
+      set_audit_user_id_and_name
+      super(sql, name)
+    end
+
+    def exec_query(*args, &block)
+      set_audit_user_id_and_name
+      super(*args, &block)
+    end
+
+    def exec_update(*args, &block)
+      set_audit_user_id_and_name
+      super(*args, &block)
+    end
+
+    def exec_delete(*args, &block)
+      set_audit_user_id_and_name
+      super(*args, &block)
+    end
+  end
+
+  prepend ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::Auditing
+  prepend ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::PgAuditLog
 
   def set_audit_user_id_and_name
     user_id, unique_name = user_id_and_name
     return true if (@last_user_id && @last_user_id == user_id) && (@last_unique_name && @last_unique_name == unique_name)
 
-    execute_without_pg_audit_log PgAuditLog::Function::user_identifier_temporary_function(user_id)
-    execute_without_pg_audit_log PgAuditLog::Function::user_unique_name_temporary_function(unique_name)
-    @last_user_id = user_id
+    PgAuditLog.execute PgAuditLog::Function::user_identifier_temporary_function(user_id)
+    PgAuditLog.execute PgAuditLog::Function::user_unique_name_temporary_function(unique_name)
+    @last_user_id     = user_id
     @last_unique_name = unique_name
 
     true
   end
 
   def set_user_id(user_id = nil)
-    execute_without_pg_audit_log PgAuditLog::Function::user_identifier_temporary_function(user_id || @last_user_id)
+    PgAuditLog.execute PgAuditLog::Function::user_identifier_temporary_function(user_id || @last_user_id)
   end
 
   def blank_audit_user_id_and_name
@@ -55,46 +87,12 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
     true
   end
 
-  def reconnect_with_pg_audit_log!
-    reconnect_without_pg_audit_log!
-    @last_user_id = @last_unique_name = nil
-  end
-  alias_method_chain :reconnect!, :pg_audit_log
-
-  def execute_with_pg_audit_log(sql, name = nil)
-    set_audit_user_id_and_name
-    conn = execute_without_pg_audit_log(sql, name = nil)
-    conn
-  end
-  alias_method_chain :execute, :pg_audit_log
-
-  def exec_query_with_pg_audit_log(*args, &block)
-    set_audit_user_id_and_name
-    conn = exec_query_without_pg_audit_log(*args, &block)
-    conn
-  end
-  alias_method_chain :exec_query, :pg_audit_log
-
-  def exec_update_with_pg_audit_log(*args, &block)
-    set_audit_user_id_and_name
-    conn = exec_update_without_pg_audit_log(*args, &block)
-    conn
-  end
-  alias_method_chain :exec_update, :pg_audit_log
-
-  def exec_delete_with_pg_audit_log(*args, &block)
-    set_audit_user_id_and_name
-    conn = exec_delete_without_pg_audit_log(*args, &block)
-    conn
-  end
-  alias_method_chain :exec_delete, :pg_audit_log
-
   private
 
   def user_id_and_name
-    current_user = Thread.current[:current_user]
-    user_id = current_user.try(:id) || "-1"
+    current_user     = Thread.current[:current_user]
+    user_id          = current_user.try(:id) || "-1"
     user_unique_name = current_user.try(:unique_name) || "UNKNOWN"
-    return [user_id, user_unique_name]
+    [user_id, user_unique_name]
   end
 end

--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -104,7 +104,7 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   private
 
   def user_id_and_name
-    current_user     = Thread.current[:current_user]
+    current_user     = Thread.current[:current_user] || RequestStore[:current_user]
     user_id          = current_user.try(:id) || "-1"
     user_unique_name = current_user.try(:unique_name) || "UNKNOWN"
     [user_id, user_unique_name]

--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -65,6 +65,15 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   alias_method :exec_update_without_pg_audit_log, :exec_update
   alias_method :exec_update, :exec_update_with_pg_audit_log
 
+  def exec_no_cache_with_pg_audit_log(*args, **opts)
+    set_audit_user_id_and_name
+    exec_no_cache_without_pg_audit_log(*args, **opts)
+  end
+
+  alias_method :exec_no_cache_without_pg_audit_log, :exec_no_cache
+  alias_method :exec_no_cache, :exec_no_cache_with_pg_audit_log
+
+
   def reconnect_with_pg_audit_log!(*args, **opts)
     reconnect_without_pg_audit_log!(*args, **opts)
     @last_user_id = @last_unique_name = nil

--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -68,23 +68,23 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   end
   alias_method_chain :execute, :pg_audit_log
 
-  def exec_query_with_pg_audit_log(sql, name = 'SQL', binds = [])
+  def exec_query_with_pg_audit_log(*args, &block)
     set_audit_user_id_and_name
-    conn = exec_query_without_pg_audit_log(sql, name, binds)
+    conn = exec_query_without_pg_audit_log(*args, &block)
     conn
   end
   alias_method_chain :exec_query, :pg_audit_log
 
-  def exec_update_with_pg_audit_log(sql, name = 'SQL', binds = [])
+  def exec_update_with_pg_audit_log(*args, &block)
     set_audit_user_id_and_name
-    conn = exec_update_without_pg_audit_log(sql, name, binds)
+    conn = exec_update_without_pg_audit_log(*args, &block)
     conn
   end
   alias_method_chain :exec_update, :pg_audit_log
 
-  def exec_delete_with_pg_audit_log(sql, name = 'SQL', binds = [])
+  def exec_delete_with_pg_audit_log(*args, &block)
     set_audit_user_id_and_name
-    conn = exec_delete_without_pg_audit_log(sql, name, binds)
+    conn = exec_delete_without_pg_audit_log(*args, &block)
     conn
   end
   alias_method_chain :exec_delete, :pg_audit_log

--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -65,15 +65,6 @@ class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
   alias_method :exec_update_without_pg_audit_log, :exec_update
   alias_method :exec_update, :exec_update_with_pg_audit_log
 
-  def exec_no_cache_with_pg_audit_log(*args, **opts)
-    set_audit_user_id_and_name
-    exec_no_cache_without_pg_audit_log(*args, **opts)
-  end
-
-  alias_method :exec_no_cache_without_pg_audit_log, :exec_no_cache
-  alias_method :exec_no_cache, :exec_no_cache_with_pg_audit_log
-
-
   def reconnect_with_pg_audit_log!(*args, **opts)
     reconnect_without_pg_audit_log!(*args, **opts)
     @last_user_id = @last_unique_name = nil

--- a/lib/pg_audit_log/function.rb
+++ b/lib/pg_audit_log/function.rb
@@ -37,9 +37,9 @@ module PgAuditLog
 
       def user_unique_name_temporary_function(username)
         if pg_audit_log_old_style_user_id
-          "SET audit.user_unique_name = '#{PGconn.escape_bytea(username)}';"
+          "SET audit.user_unique_name = '#{PG::Connection.escape_bytea(username)}';"
         else
-          "CREATE OR REPLACE FUNCTION pg_temp.pg_audit_log_user_unique_name() RETURNS varchar AS $_$ SELECT '#{PGconn.escape_bytea(username)}'::varchar $_$ LANGUAGE SQL STABLE;"
+          "CREATE OR REPLACE FUNCTION pg_temp.pg_audit_log_user_unique_name() RETURNS varchar AS $_$ SELECT '#{PG::Connection.escape_bytea(username)}'::varchar $_$ LANGUAGE SQL STABLE;"
         end
       end
 

--- a/lib/pg_audit_log/function.rb
+++ b/lib/pg_audit_log/function.rb
@@ -75,7 +75,7 @@ module PgAuditLog
               INTO primary_key_column USING TG_RELNAME;
               primary_key_value := NULL;
 
-              FOR col IN SELECT * FROM information_schema.columns WHERE table_name = TG_RELNAME LOOP
+              FOR col IN SELECT * FROM information_schema.columns WHERE table_name = TG_RELNAME AND TABLE_schema = 'public' LOOP
                 new_value := NULL;
                 old_value := NULL;
                 column_name := col.column_name;

--- a/lib/pg_audit_log/triggers.rb
+++ b/lib/pg_audit_log/triggers.rb
@@ -49,18 +49,21 @@ module PgAuditLog
       end
 
       def enable
+        @disabled = false
         connection.set_user_id(nil)
       end
 
       def disable
+        @disabled = true
         connection.set_user_id(PgAuditLog::Function::DISABLED_USER)
       end
 
       def without_triggers
-        disable
+        was_disabled = @disabled
+        disable unless was_disabled
         yield
       ensure
-        enable
+        enable unless was_disabled
       end
 
       def create_for_table(table_name)

--- a/lib/pg_audit_log/version.rb
+++ b/lib/pg_audit_log/version.rb
@@ -1,3 +1,3 @@
 module PgAuditLog
-  VERSION = '0.6.7'.freeze
+  VERSION = '0.7.0'.freeze
 end

--- a/lib/pg_audit_log/version.rb
+++ b/lib/pg_audit_log/version.rb
@@ -1,3 +1,3 @@
 module PgAuditLog
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.7.1'.freeze
 end

--- a/lib/pg_audit_log/version.rb
+++ b/lib/pg_audit_log/version.rb
@@ -1,3 +1,3 @@
 module PgAuditLog
-  VERSION = '0.6.6'.freeze
+  VERSION = '0.6.7'.freeze
 end

--- a/pg_audit_log.gemspec
+++ b/pg_audit_log.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '>= 4.2', '< 5.3'
-  spec.add_dependency 'pg', '~> 1.1.4'
+  spec.add_dependency 'rails', '>= 4.2', '< 6.1'
+  spec.add_dependency 'pg', '~> 1.2.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'with_model', '>= 0.1.3'

--- a/pg_audit_log.gemspec
+++ b/pg_audit_log.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '>= 4.2', '< 5.1'
+  spec.add_dependency 'rails', '>= 4.2', '< 5.3'
   spec.add_dependency 'pg', '>= 0.9.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-rails'

--- a/pg_audit_log.gemspec
+++ b/pg_audit_log.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '>= 4.2', '< 6.2'
-  spec.add_dependency 'pg', '~> 1.2.3'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_dependency 'rails', '>= 4.2'
+  spec.add_dependency 'pg', '>= 1.2.3'
+  spec.add_development_dependency 'rspec', '>= 3.0'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'with_model', '>= 0.1.3'
 end

--- a/pg_audit_log.gemspec
+++ b/pg_audit_log.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '>= 4.2', '< 6.1'
+  spec.add_dependency 'rails', '>= 4.2', '< 6.2'
   spec.add_dependency 'pg', '~> 1.2.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-rails'

--- a/pg_audit_log.gemspec
+++ b/pg_audit_log.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rails', '>= 4.2', '< 5.3'
-  spec.add_dependency 'pg', '>= 0.9.0'
+  spec.add_dependency 'pg', '~> 1.1.4'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'with_model', '>= 0.1.3'

--- a/pg_audit_log.gemspec
+++ b/pg_audit_log.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '>= 3.2', '< 4.3'
+  spec.add_dependency 'rails', '>= 4.2', '< 5.1'
   spec.add_dependency 'pg', '>= 0.9.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-rails'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,11 +9,12 @@ begin
   ActiveRecord::Base.establish_connection({
     :adapter  => 'postgresql',
     :database => 'pg_audit_log_test',
+    :password => 'bar',
     :min_messages => 'warning',
   })
   connection = ActiveRecord::Base.connection
   connection.execute('SELECT 1')
-rescue PGError => e
+rescue PG::Error => e
   puts '-' * 80
   puts 'Unable to connect to database.  Please run:'
   puts

--- a/spec/triggers_spec.rb
+++ b/spec/triggers_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe PgAuditLog::Triggers do
   before :each do
+    PgAuditLog::Triggers.enable
     PgAuditLog::Triggers.uninstall rescue nil
   end
 
@@ -131,6 +132,20 @@ describe PgAuditLog::Triggers do
           TableWithTriggers.create!
         }.to change(PgAuditLog::Entry, :count)
         expect(PgAuditLog::Entry.last.user_id).to eq(-1)
+      end
+
+      context 'when nested' do
+        it 'does not enable prematurely' do
+          expect {
+            PgAuditLog::Triggers.without_triggers do
+              TableWithTriggers.create!
+              PgAuditLog::Triggers.without_triggers do
+                TableWithTriggers.create!
+              end
+              TableWithTriggers.create!
+            end
+          }.to_not change(PgAuditLog::Entry, :count)
+        end
       end
     end
 


### PR DESCRIPTION
DO NOT MERGE as **subvertical:verticalchange** will reference the **'rails-5'** branch directly for Rail next code (gated by `rails_next?` method).  The existing Rail v4, verticalchange Gemfile will continue to reference the **pg_audit_log** master branch.. Messy but will clean up after migration to rails next (v6) happens..


Currently, no issues experienced as Rails next testing continues....